### PR TITLE
feat: add Managed Agents API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,79 @@
 # Terraform Provider Anthropic
 
-Unofficial Terraform provider for Anthropic.
+Terraform provider for Anthropic — manages Admin API resources (workspaces, members, invites) and **Managed Agents API** resources (agents, environments).
 
-## Support Development
+> Fork of [jianyuan/terraform-provider-anthropic](https://github.com/jianyuan/terraform-provider-anthropic) with Managed Agents support added.
 
-If you find this provider useful, please consider supporting me through GitHub Sponsorship or Ko-Fi to help with its development.
+## Resources
 
-[![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/jianyuan)
-[![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/L3L71DQEL)
+### Admin API
+- `anthropic_workspace` — Create and manage workspaces
+- `anthropic_workspace_member` — Manage workspace members
+- `anthropic_organization_invite` — Manage organization invites
+
+### Managed Agents API (Beta)
+- `anthropic_agent` — Create and manage agents with models, tools, MCP servers, and skills
+- `anthropic_environment` — Create and manage agent environments with networking and packages
+
+### Data Sources
+- `anthropic_agents` — List all managed agents
+- `anthropic_environments` — List all environments
+- `anthropic_workspace`, `anthropic_workspaces`, `anthropic_user`, `anthropic_users`, etc.
+
+## Usage
+
+```hcl
+terraform {
+  required_providers {
+    anthropic = {
+      source = "frank-bee/anthropic"
+    }
+  }
+}
+
+provider "anthropic" {
+  # Set via ANTHROPIC_API_KEY env var
+}
+
+resource "anthropic_agent" "assistant" {
+  name  = "my-assistant"
+  model = "claude-sonnet-4-5"
+
+  tools {
+    type = "agent_toolset_20251212"
+  }
+}
+
+resource "anthropic_environment" "dev" {
+  name            = "dev-environment"
+  networking_type = "unrestricted"
+  packages = {
+    "python" = "3.12"
+  }
+}
+```
 
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
 - [Go](https://golang.org/doc/install) >= 1.22
 
-## Building The Provider
-
-1. Clone the repository
-1. Enter the repository directory
-1. Build the provider using the Go `install` command:
+## Building
 
 ```shell
 go install
 ```
 
-## Adding Dependencies
-
-This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).
-Please see the Go documentation for the most up to date information about using Go modules.
-
-To add a new dependency `github.com/author/dependency` to your Terraform provider:
+## Testing
 
 ```shell
-go get github.com/author/dependency
-go mod tidy
-```
+# Unit tests
+make test
 
-Then commit the changes to `go.mod` and `go.sum`.
-
-## Using the provider
-
-Please refer to the [provider documentation on the Terraform registry](https://registry.terraform.io/providers/jianyuan/anthropic/latest/docs).
-
-## Developing the Provider
-
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
-
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
-
-To generate or update documentation, run `make generate`.
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-_Note:_ Acceptance tests create real resources, and often cost money to run.
-
-```shell
+# Acceptance tests (requires ANTHROPIC_API_KEY)
 make testacc
 ```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/examples/data-sources/anthropic_agents/data-source.tf
+++ b/examples/data-sources/anthropic_agents/data-source.tf
@@ -1,0 +1,5 @@
+data "anthropic_agents" "all" {}
+
+output "agents" {
+  value = data.anthropic_agents.all.agents
+}

--- a/examples/data-sources/anthropic_environments/data-source.tf
+++ b/examples/data-sources/anthropic_environments/data-source.tf
@@ -1,0 +1,5 @@
+data "anthropic_environments" "all" {}
+
+output "environments" {
+  value = data.anthropic_environments.all.environments
+}

--- a/examples/resources/anthropic_agent/resource.tf
+++ b/examples/resources/anthropic_agent/resource.tf
@@ -1,0 +1,44 @@
+# Basic agent with a model
+resource "anthropic_agent" "basic" {
+  name  = "my-assistant"
+  model = "claude-sonnet-4-5"
+}
+
+# Agent with system prompt and tools
+resource "anthropic_agent" "with_tools" {
+  name   = "devops-agent"
+  model  = "claude-sonnet-4-5"
+  system = "You are a DevOps assistant that helps with infrastructure tasks."
+
+  tools {
+    type = "agent_toolset_20251212"
+  }
+}
+
+# Agent with MCP server
+resource "anthropic_agent" "with_mcp" {
+  name  = "mcp-agent"
+  model = "claude-sonnet-4-5"
+
+  tools {
+    type = "agent_toolset_20251212"
+  }
+
+  mcp_servers {
+    name = "my-server"
+    type = "url"
+    url  = "https://mcp.example.com/sse"
+  }
+}
+
+# Agent with skills
+resource "anthropic_agent" "with_skills" {
+  name  = "skilled-agent"
+  model = "claude-opus-4-5"
+
+  skills {
+    skill_id = "computer_use"
+    type     = "anthropic"
+    version  = "1.0"
+  }
+}

--- a/examples/resources/anthropic_environment/resource.tf
+++ b/examples/resources/anthropic_environment/resource.tf
@@ -1,0 +1,15 @@
+# Basic environment with unrestricted networking
+resource "anthropic_environment" "basic" {
+  name            = "dev-environment"
+  networking_type = "unrestricted"
+}
+
+# Restricted environment with packages
+resource "anthropic_environment" "with_packages" {
+  name            = "python-env"
+  networking_type = "restricted"
+  packages = {
+    "python" = "3.12"
+    "node"   = "20"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jianyuan/terraform-provider-anthropic
+module github.com/frank-bee/terraform-provider-anthropic
 
 go 1.26.1
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 	"github.com/jianyuan/go-utils/must"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
 )
 
 var (
@@ -22,6 +22,7 @@ func init() {
 		"https://api.anthropic.com",
 		apiclient.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("anthropic-version", "2023-06-01")
+			req.Header.Set("anthropic-beta", "agent-api-2026-03-01")
 			req.Header.Set("x-api-key", TestApiKey)
 			return nil
 		}),
@@ -35,5 +36,11 @@ func PreCheck(t *testing.T) {
 
 	if TestUserId == "" {
 		t.Fatal("ANTHROPIC_TEST_USER_ID must be set for acceptance tests")
+	}
+}
+
+func PreCheckManagedAgents(t *testing.T) {
+	if TestApiKey == "" {
+		t.Fatal("ANTHROPIC_API_KEY must be set for acceptance tests")
 	}
 }

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -345,6 +345,186 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  # ==================== Managed Agents API ====================
+  /v1/agents:
+    get:
+      operationId: listAgents
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+        - name: page
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Agent"
+                  next_page:
+                    type: string
+                    nullable: true
+    post:
+      operationId: createAgent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAgentRequest"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+  /v1/agents/{agent_id}:
+    get:
+      operationId: getAgent
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+    post:
+      operationId: updateAgent
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAgentRequest"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+    delete:
+      operationId: deleteAgent
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeletedResource"
+  /v1/environments:
+    get:
+      operationId: listEnvironments
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+        - name: page
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Environment"
+                  next_page:
+                    type: string
+                    nullable: true
+    post:
+      operationId: createEnvironment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEnvironmentRequest"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Environment"
+  /v1/environments/{environment_id}:
+    get:
+      operationId: getEnvironment
+      parameters:
+        - name: environment_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Environment"
+    post:
+      operationId: updateEnvironment
+      parameters:
+        - name: environment_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEnvironmentRequest"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Environment"
+    delete:
+      operationId: deleteEnvironment
+      parameters:
+        - name: environment_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeletedResource"
+  # ==================== End Managed Agents API ====================
   /v1/organizations/workspaces/{workspace_id}/members/{user_id}:
     get:
       operationId: getWorkspaceMember
@@ -515,4 +695,217 @@ components:
         workspace_id:
           type: string
         workspace_role:
+          type: string
+    # ==================== Managed Agents Schemas ====================
+    AgentModelConfig:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        speed:
+          type: string
+    AgentSkill:
+      type: object
+      required:
+        - skill_id
+        - type
+        - version
+      properties:
+        skill_id:
+          type: string
+        type:
+          type: string
+        version:
+          type: string
+    AgentSkillRequest:
+      type: object
+      required:
+        - id
+        - type
+        - version
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        version:
+          type: string
+    AgentTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+    AgentMcpServer:
+      type: object
+      required:
+        - name
+        - type
+        - url
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
+    Agent:
+      type: object
+      required:
+        - id
+        - type
+        - version
+        - name
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        version:
+          type: string
+        name:
+          type: string
+        model:
+          type: string
+        system:
+          type: string
+          nullable: true
+        status:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+          nullable: true
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentSkill"
+        tools:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentTool"
+        mcp_servers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentMcpServer"
+    CreateAgentRequest:
+      type: object
+      required:
+        - name
+        - model
+      properties:
+        name:
+          type: string
+        model:
+          type: string
+        system:
+          type: string
+        tools:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentTool"
+        mcp_servers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentMcpServer"
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentSkillRequest"
+    UpdateAgentRequest:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: string
+        name:
+          type: string
+        model:
+          type: string
+        system:
+          type: string
+        tools:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentTool"
+        mcp_servers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentMcpServer"
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentSkillRequest"
+    EnvironmentNetworking:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+    EnvironmentConfig:
+      type: object
+      required:
+        - type
+        - networking
+      properties:
+        type:
+          type: string
+        networking:
+          $ref: "#/components/schemas/EnvironmentNetworking"
+        packages:
+          type: object
+          additionalProperties:
+            type: string
+    Environment:
+      type: object
+      required:
+        - id
+        - type
+        - name
+        - config
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        config:
+          $ref: "#/components/schemas/EnvironmentConfig"
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    CreateEnvironmentRequest:
+      type: object
+      required:
+        - name
+        - config
+      properties:
+        name:
+          type: string
+        config:
+          $ref: "#/components/schemas/EnvironmentConfig"
+    UpdateEnvironmentRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        config:
+          $ref: "#/components/schemas/EnvironmentConfig"
+    DeletedResource:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+        type:
           type: string

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -21,6 +21,92 @@ const (
 	VersionHeaderScopes = "versionHeader.Scopes"
 )
 
+// Agent defines model for Agent.
+type Agent struct {
+	CreatedAt  *string           `json:"created_at,omitempty"`
+	Id         string            `json:"id"`
+	McpServers *[]AgentMcpServer `json:"mcp_servers,omitempty"`
+	Model      *string           `json:"model,omitempty"`
+	Name       string            `json:"name"`
+	Skills     *[]AgentSkill     `json:"skills,omitempty"`
+	Status     *string           `json:"status,omitempty"`
+	System     *string           `json:"system,omitempty"`
+	Tools      *[]AgentTool      `json:"tools,omitempty"`
+	Type       string            `json:"type"`
+	UpdatedAt  *string           `json:"updated_at,omitempty"`
+	Version    string            `json:"version"`
+}
+
+// AgentMcpServer defines model for AgentMcpServer.
+type AgentMcpServer struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Url  string `json:"url"`
+}
+
+// AgentSkill defines model for AgentSkill.
+type AgentSkill struct {
+	SkillId string `json:"skill_id"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+// AgentSkillRequest defines model for AgentSkillRequest.
+type AgentSkillRequest struct {
+	Id      string `json:"id"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+// AgentTool defines model for AgentTool.
+type AgentTool struct {
+	Type string `json:"type"`
+}
+
+// CreateAgentRequest defines model for CreateAgentRequest.
+type CreateAgentRequest struct {
+	McpServers *[]AgentMcpServer    `json:"mcp_servers,omitempty"`
+	Model      string               `json:"model"`
+	Name       string               `json:"name"`
+	Skills     *[]AgentSkillRequest `json:"skills,omitempty"`
+	System     *string              `json:"system,omitempty"`
+	Tools      *[]AgentTool         `json:"tools,omitempty"`
+}
+
+// CreateEnvironmentRequest defines model for CreateEnvironmentRequest.
+type CreateEnvironmentRequest struct {
+	Config EnvironmentConfig `json:"config"`
+	Name   string            `json:"name"`
+}
+
+// DeletedResource defines model for DeletedResource.
+type DeletedResource struct {
+	Id   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// Environment defines model for Environment.
+type Environment struct {
+	Config    EnvironmentConfig `json:"config"`
+	CreatedAt *string           `json:"created_at,omitempty"`
+	Id        string            `json:"id"`
+	Name      string            `json:"name"`
+	Type      string            `json:"type"`
+	UpdatedAt *string           `json:"updated_at,omitempty"`
+}
+
+// EnvironmentConfig defines model for EnvironmentConfig.
+type EnvironmentConfig struct {
+	Networking EnvironmentNetworking `json:"networking"`
+	Packages   *map[string]string    `json:"packages,omitempty"`
+	Type       string                `json:"type"`
+}
+
+// EnvironmentNetworking defines model for EnvironmentNetworking.
+type EnvironmentNetworking struct {
+	Type string `json:"type"`
+}
+
 // Error defines model for Error.
 type Error struct {
 	Error struct {
@@ -37,6 +123,23 @@ type Invite struct {
 	Id        string `json:"id"`
 	Role      string `json:"role"`
 	Status    string `json:"status"`
+}
+
+// UpdateAgentRequest defines model for UpdateAgentRequest.
+type UpdateAgentRequest struct {
+	McpServers *[]AgentMcpServer    `json:"mcp_servers,omitempty"`
+	Model      *string              `json:"model,omitempty"`
+	Name       *string              `json:"name,omitempty"`
+	Skills     *[]AgentSkillRequest `json:"skills,omitempty"`
+	System     *string              `json:"system,omitempty"`
+	Tools      *[]AgentTool         `json:"tools,omitempty"`
+	Version    string               `json:"version"`
+}
+
+// UpdateEnvironmentRequest defines model for UpdateEnvironmentRequest.
+type UpdateEnvironmentRequest struct {
+	Config *EnvironmentConfig `json:"config,omitempty"`
+	Name   *string            `json:"name,omitempty"`
 }
 
 // User defines model for User.
@@ -62,6 +165,18 @@ type WorkspaceMember struct {
 	UserId        string `json:"user_id"`
 	WorkspaceId   string `json:"workspace_id"`
 	WorkspaceRole string `json:"workspace_role"`
+}
+
+// ListAgentsParams defines parameters for ListAgents.
+type ListAgentsParams struct {
+	Limit *int    `form:"limit,omitempty" json:"limit,omitempty"`
+	Page  *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
+// ListEnvironmentsParams defines parameters for ListEnvironments.
+type ListEnvironmentsParams struct {
+	Limit *int    `form:"limit,omitempty" json:"limit,omitempty"`
+	Page  *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListInvitesParams defines parameters for ListInvites.
@@ -119,6 +234,18 @@ type CreateWorkspaceMemberJSONBody struct {
 type UpdateWorkspaceMemberJSONBody struct {
 	WorkspaceRole string `json:"workspace_role"`
 }
+
+// CreateAgentJSONRequestBody defines body for CreateAgent for application/json ContentType.
+type CreateAgentJSONRequestBody = CreateAgentRequest
+
+// UpdateAgentJSONRequestBody defines body for UpdateAgent for application/json ContentType.
+type UpdateAgentJSONRequestBody = UpdateAgentRequest
+
+// CreateEnvironmentJSONRequestBody defines body for CreateEnvironment for application/json ContentType.
+type CreateEnvironmentJSONRequestBody = CreateEnvironmentRequest
+
+// UpdateEnvironmentJSONRequestBody defines body for UpdateEnvironment for application/json ContentType.
+type UpdateEnvironmentJSONRequestBody = UpdateEnvironmentRequest
 
 // CreateInviteJSONRequestBody defines body for CreateInvite for application/json ContentType.
 type CreateInviteJSONRequestBody CreateInviteJSONBody
@@ -208,6 +335,44 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// ListAgents request
+	ListAgents(ctx context.Context, params *ListAgentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateAgentWithBody request with any body
+	CreateAgentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateAgent(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAgent request
+	DeleteAgent(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAgent request
+	GetAgent(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAgentWithBody request with any body
+	UpdateAgentWithBody(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAgent(ctx context.Context, agentId string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListEnvironments request
+	ListEnvironments(ctx context.Context, params *ListEnvironmentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateEnvironmentWithBody request with any body
+	CreateEnvironmentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateEnvironment(ctx context.Context, body CreateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteEnvironment request
+	DeleteEnvironment(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetEnvironment request
+	GetEnvironment(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateEnvironmentWithBody request with any body
+	UpdateEnvironmentWithBody(ctx context.Context, environmentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateEnvironment(ctx context.Context, environmentId string, body UpdateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListInvites request
 	ListInvites(ctx context.Context, params *ListInvitesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -265,6 +430,174 @@ type ClientInterface interface {
 	UpdateWorkspaceMemberWithBody(ctx context.Context, workspaceId string, userId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateWorkspaceMember(ctx context.Context, workspaceId string, userId string, body UpdateWorkspaceMemberJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) ListAgents(ctx context.Context, params *ListAgentsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAgentsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateAgentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAgentRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateAgent(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAgentRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAgent(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAgentRequest(c.Server, agentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAgent(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAgentRequest(c.Server, agentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAgentWithBody(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAgentRequestWithBody(c.Server, agentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAgent(ctx context.Context, agentId string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAgentRequest(c.Server, agentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListEnvironments(ctx context.Context, params *ListEnvironmentsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEnvironmentsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateEnvironmentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEnvironmentRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateEnvironment(ctx context.Context, body CreateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEnvironmentRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteEnvironment(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteEnvironmentRequest(c.Server, environmentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetEnvironment(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEnvironmentRequest(c.Server, environmentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateEnvironmentWithBody(ctx context.Context, environmentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateEnvironmentRequestWithBody(c.Server, environmentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateEnvironment(ctx context.Context, environmentId string, body UpdateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateEnvironmentRequest(c.Server, environmentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) ListInvites(ctx context.Context, params *ListInvitesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -517,6 +850,446 @@ func (c *Client) UpdateWorkspaceMember(ctx context.Context, workspaceId string, 
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewListAgentsRequest generates requests for ListAgents
+func NewListAgentsRequest(server string, params *ListAgentsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/agents")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "page", *params.Page, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateAgentRequest calls the generic CreateAgent builder with application/json body
+func NewCreateAgentRequest(server string, body CreateAgentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateAgentRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateAgentRequestWithBody generates requests for CreateAgent with any type of body
+func NewCreateAgentRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/agents")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAgentRequest generates requests for DeleteAgent
+func NewDeleteAgentRequest(server string, agentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agent_id", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/agents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetAgentRequest generates requests for GetAgent
+func NewGetAgentRequest(server string, agentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agent_id", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/agents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAgentRequest calls the generic UpdateAgent builder with application/json body
+func NewUpdateAgentRequest(server string, agentId string, body UpdateAgentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAgentRequestWithBody(server, agentId, "application/json", bodyReader)
+}
+
+// NewUpdateAgentRequestWithBody generates requests for UpdateAgent with any type of body
+func NewUpdateAgentRequestWithBody(server string, agentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agent_id", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/agents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListEnvironmentsRequest generates requests for ListEnvironments
+func NewListEnvironmentsRequest(server string, params *ListEnvironmentsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/environments")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "page", *params.Page, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateEnvironmentRequest calls the generic CreateEnvironment builder with application/json body
+func NewCreateEnvironmentRequest(server string, body CreateEnvironmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateEnvironmentRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateEnvironmentRequestWithBody generates requests for CreateEnvironment with any type of body
+func NewCreateEnvironmentRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/environments")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteEnvironmentRequest generates requests for DeleteEnvironment
+func NewDeleteEnvironmentRequest(server string, environmentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "environment_id", environmentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/environments/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetEnvironmentRequest generates requests for GetEnvironment
+func NewGetEnvironmentRequest(server string, environmentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "environment_id", environmentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/environments/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateEnvironmentRequest calls the generic UpdateEnvironment builder with application/json body
+func NewUpdateEnvironmentRequest(server string, environmentId string, body UpdateEnvironmentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateEnvironmentRequestWithBody(server, environmentId, "application/json", bodyReader)
+}
+
+// NewUpdateEnvironmentRequestWithBody generates requests for UpdateEnvironment with any type of body
+func NewUpdateEnvironmentRequestWithBody(server string, environmentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "environment_id", environmentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/environments/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
 }
 
 // NewListInvitesRequest generates requests for ListInvites
@@ -1389,6 +2162,44 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// ListAgentsWithResponse request
+	ListAgentsWithResponse(ctx context.Context, params *ListAgentsParams, reqEditors ...RequestEditorFn) (*ListAgentsResponse, error)
+
+	// CreateAgentWithBodyWithResponse request with any body
+	CreateAgentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error)
+
+	CreateAgentWithResponse(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error)
+
+	// DeleteAgentWithResponse request
+	DeleteAgentWithResponse(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*DeleteAgentResponse, error)
+
+	// GetAgentWithResponse request
+	GetAgentWithResponse(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*GetAgentResponse, error)
+
+	// UpdateAgentWithBodyWithResponse request with any body
+	UpdateAgentWithBodyWithResponse(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error)
+
+	UpdateAgentWithResponse(ctx context.Context, agentId string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error)
+
+	// ListEnvironmentsWithResponse request
+	ListEnvironmentsWithResponse(ctx context.Context, params *ListEnvironmentsParams, reqEditors ...RequestEditorFn) (*ListEnvironmentsResponse, error)
+
+	// CreateEnvironmentWithBodyWithResponse request with any body
+	CreateEnvironmentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEnvironmentResponse, error)
+
+	CreateEnvironmentWithResponse(ctx context.Context, body CreateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEnvironmentResponse, error)
+
+	// DeleteEnvironmentWithResponse request
+	DeleteEnvironmentWithResponse(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*DeleteEnvironmentResponse, error)
+
+	// GetEnvironmentWithResponse request
+	GetEnvironmentWithResponse(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*GetEnvironmentResponse, error)
+
+	// UpdateEnvironmentWithBodyWithResponse request with any body
+	UpdateEnvironmentWithBodyWithResponse(ctx context.Context, environmentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEnvironmentResponse, error)
+
+	UpdateEnvironmentWithResponse(ctx context.Context, environmentId string, body UpdateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEnvironmentResponse, error)
+
 	// ListInvitesWithResponse request
 	ListInvitesWithResponse(ctx context.Context, params *ListInvitesParams, reqEditors ...RequestEditorFn) (*ListInvitesResponse, error)
 
@@ -1446,6 +2257,232 @@ type ClientWithResponsesInterface interface {
 	UpdateWorkspaceMemberWithBodyWithResponse(ctx context.Context, workspaceId string, userId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateWorkspaceMemberResponse, error)
 
 	UpdateWorkspaceMemberWithResponse(ctx context.Context, workspaceId string, userId string, body UpdateWorkspaceMemberJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateWorkspaceMemberResponse, error)
+}
+
+type ListAgentsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data     []Agent `json:"data"`
+		NextPage *string `json:"next_page,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAgentsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAgentsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Agent
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DeletedResource
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Agent
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Agent
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListEnvironmentsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data     []Environment `json:"data"`
+		NextPage *string       `json:"next_page,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListEnvironmentsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListEnvironmentsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateEnvironmentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Environment
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateEnvironmentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateEnvironmentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteEnvironmentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DeletedResource
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteEnvironmentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteEnvironmentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetEnvironmentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Environment
+}
+
+// Status returns HTTPResponse.Status
+func (r GetEnvironmentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetEnvironmentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateEnvironmentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Environment
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateEnvironmentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateEnvironmentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type ListInvitesResponse struct {
@@ -1821,6 +2858,128 @@ func (r UpdateWorkspaceMemberResponse) StatusCode() int {
 	return 0
 }
 
+// ListAgentsWithResponse request returning *ListAgentsResponse
+func (c *ClientWithResponses) ListAgentsWithResponse(ctx context.Context, params *ListAgentsParams, reqEditors ...RequestEditorFn) (*ListAgentsResponse, error) {
+	rsp, err := c.ListAgents(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAgentsResponse(rsp)
+}
+
+// CreateAgentWithBodyWithResponse request with arbitrary body returning *CreateAgentResponse
+func (c *ClientWithResponses) CreateAgentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error) {
+	rsp, err := c.CreateAgentWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateAgentResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateAgentWithResponse(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error) {
+	rsp, err := c.CreateAgent(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateAgentResponse(rsp)
+}
+
+// DeleteAgentWithResponse request returning *DeleteAgentResponse
+func (c *ClientWithResponses) DeleteAgentWithResponse(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*DeleteAgentResponse, error) {
+	rsp, err := c.DeleteAgent(ctx, agentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAgentResponse(rsp)
+}
+
+// GetAgentWithResponse request returning *GetAgentResponse
+func (c *ClientWithResponses) GetAgentWithResponse(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*GetAgentResponse, error) {
+	rsp, err := c.GetAgent(ctx, agentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAgentResponse(rsp)
+}
+
+// UpdateAgentWithBodyWithResponse request with arbitrary body returning *UpdateAgentResponse
+func (c *ClientWithResponses) UpdateAgentWithBodyWithResponse(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error) {
+	rsp, err := c.UpdateAgentWithBody(ctx, agentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAgentResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAgentWithResponse(ctx context.Context, agentId string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error) {
+	rsp, err := c.UpdateAgent(ctx, agentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAgentResponse(rsp)
+}
+
+// ListEnvironmentsWithResponse request returning *ListEnvironmentsResponse
+func (c *ClientWithResponses) ListEnvironmentsWithResponse(ctx context.Context, params *ListEnvironmentsParams, reqEditors ...RequestEditorFn) (*ListEnvironmentsResponse, error) {
+	rsp, err := c.ListEnvironments(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEnvironmentsResponse(rsp)
+}
+
+// CreateEnvironmentWithBodyWithResponse request with arbitrary body returning *CreateEnvironmentResponse
+func (c *ClientWithResponses) CreateEnvironmentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEnvironmentResponse, error) {
+	rsp, err := c.CreateEnvironmentWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEnvironmentResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateEnvironmentWithResponse(ctx context.Context, body CreateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEnvironmentResponse, error) {
+	rsp, err := c.CreateEnvironment(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEnvironmentResponse(rsp)
+}
+
+// DeleteEnvironmentWithResponse request returning *DeleteEnvironmentResponse
+func (c *ClientWithResponses) DeleteEnvironmentWithResponse(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*DeleteEnvironmentResponse, error) {
+	rsp, err := c.DeleteEnvironment(ctx, environmentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteEnvironmentResponse(rsp)
+}
+
+// GetEnvironmentWithResponse request returning *GetEnvironmentResponse
+func (c *ClientWithResponses) GetEnvironmentWithResponse(ctx context.Context, environmentId string, reqEditors ...RequestEditorFn) (*GetEnvironmentResponse, error) {
+	rsp, err := c.GetEnvironment(ctx, environmentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEnvironmentResponse(rsp)
+}
+
+// UpdateEnvironmentWithBodyWithResponse request with arbitrary body returning *UpdateEnvironmentResponse
+func (c *ClientWithResponses) UpdateEnvironmentWithBodyWithResponse(ctx context.Context, environmentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEnvironmentResponse, error) {
+	rsp, err := c.UpdateEnvironmentWithBody(ctx, environmentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateEnvironmentResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateEnvironmentWithResponse(ctx context.Context, environmentId string, body UpdateEnvironmentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEnvironmentResponse, error) {
+	rsp, err := c.UpdateEnvironment(ctx, environmentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateEnvironmentResponse(rsp)
+}
+
 // ListInvitesWithResponse request returning *ListInvitesResponse
 func (c *ClientWithResponses) ListInvitesWithResponse(ctx context.Context, params *ListInvitesParams, reqEditors ...RequestEditorFn) (*ListInvitesResponse, error) {
 	rsp, err := c.ListInvites(ctx, params, reqEditors...)
@@ -2003,6 +3162,272 @@ func (c *ClientWithResponses) UpdateWorkspaceMemberWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseUpdateWorkspaceMemberResponse(rsp)
+}
+
+// ParseListAgentsResponse parses an HTTP response from a ListAgentsWithResponse call
+func ParseListAgentsResponse(rsp *http.Response) (*ListAgentsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAgentsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data     []Agent `json:"data"`
+			NextPage *string `json:"next_page,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateAgentResponse parses an HTTP response from a CreateAgentWithResponse call
+func ParseCreateAgentResponse(rsp *http.Response) (*CreateAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Agent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAgentResponse parses an HTTP response from a DeleteAgentWithResponse call
+func ParseDeleteAgentResponse(rsp *http.Response) (*DeleteAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DeletedResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAgentResponse parses an HTTP response from a GetAgentWithResponse call
+func ParseGetAgentResponse(rsp *http.Response) (*GetAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Agent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAgentResponse parses an HTTP response from a UpdateAgentWithResponse call
+func ParseUpdateAgentResponse(rsp *http.Response) (*UpdateAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Agent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListEnvironmentsResponse parses an HTTP response from a ListEnvironmentsWithResponse call
+func ParseListEnvironmentsResponse(rsp *http.Response) (*ListEnvironmentsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListEnvironmentsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data     []Environment `json:"data"`
+			NextPage *string       `json:"next_page,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateEnvironmentResponse parses an HTTP response from a CreateEnvironmentWithResponse call
+func ParseCreateEnvironmentResponse(rsp *http.Response) (*CreateEnvironmentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateEnvironmentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Environment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteEnvironmentResponse parses an HTTP response from a DeleteEnvironmentWithResponse call
+func ParseDeleteEnvironmentResponse(rsp *http.Response) (*DeleteEnvironmentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteEnvironmentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DeletedResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetEnvironmentResponse parses an HTTP response from a GetEnvironmentWithResponse call
+func ParseGetEnvironmentResponse(rsp *http.Response) (*GetEnvironmentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetEnvironmentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Environment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateEnvironmentResponse parses an HTTP response from a UpdateEnvironmentWithResponse call
+func ParseUpdateEnvironmentResponse(rsp *http.Response) (*UpdateEnvironmentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateEnvironmentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Environment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseListInvitesResponse parses an HTTP response from a ListInvitesWithResponse call

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type baseDataSource struct {

--- a/internal/provider/data_source_agents.go
+++ b/internal/provider/data_source_agents.go
@@ -1,0 +1,121 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func NewAgentsDataSource() datasource.DataSource {
+	return &AgentsDataSource{}
+}
+
+var _ datasource.DataSource = &AgentsDataSource{}
+
+type AgentsDataSource struct {
+	baseDataSource
+}
+
+type AgentsDataSourceModel struct {
+	Agents []AgentDataSourceModel `tfsdk:"agents"`
+}
+
+type AgentDataSourceModel struct {
+	Id      types.String `tfsdk:"id"`
+	Name    types.String `tfsdk:"name"`
+	Model   types.String `tfsdk:"model"`
+	Version types.String `tfsdk:"version"`
+}
+
+func (d *AgentsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_agents"
+}
+
+func (d *AgentsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "List all Managed Agents.",
+
+		Attributes: map[string]schema.Attribute{
+			"agents": schema.ListNestedAttribute{
+				MarkdownDescription: "List of agents.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							MarkdownDescription: "ID of the Agent.",
+							Computed:            true,
+						},
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Name of the Agent.",
+							Computed:            true,
+						},
+						"model": schema.StringAttribute{
+							MarkdownDescription: "Model ID of the Agent.",
+							Computed:            true,
+						},
+						"version": schema.StringAttribute{
+							MarkdownDescription: "Version of the Agent.",
+							Computed:            true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *AgentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data AgentsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var allAgents []AgentDataSourceModel
+
+	var page *string
+	for {
+		params := &apiclient.ListAgentsParams{}
+		if page != nil {
+			params.Page = page
+		}
+
+		httpResp, err := d.client.ListAgentsWithResponse(ctx, params)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list agents, got error: %s", err))
+			return
+		}
+
+		if httpResp.StatusCode() != http.StatusOK {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list agents, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+			return
+		}
+
+		if httpResp.JSON200 == nil {
+			break
+		}
+
+		for _, a := range httpResp.JSON200.Data {
+			allAgents = append(allAgents, AgentDataSourceModel{
+				Id:      types.StringValue(a.Id),
+				Name:    types.StringValue(a.Name),
+				Model:   types.StringPointerValue(a.Model),
+				Version: types.StringValue(a.Version),
+			})
+		}
+
+		if httpResp.JSON200.NextPage == nil || *httpResp.JSON200.NextPage == "" {
+			break
+		}
+		page = httpResp.JSON200.NextPage
+	}
+
+	data.Agents = allAgents
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_environments.go
+++ b/internal/provider/data_source_environments.go
@@ -1,0 +1,121 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func NewEnvironmentsDataSource() datasource.DataSource {
+	return &EnvironmentsDataSource{}
+}
+
+var _ datasource.DataSource = &EnvironmentsDataSource{}
+
+type EnvironmentsDataSource struct {
+	baseDataSource
+}
+
+type EnvironmentsDataSourceModel struct {
+	Environments []EnvironmentDataSourceModel `tfsdk:"environments"`
+}
+
+type EnvironmentDataSourceModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	ConfigType     types.String `tfsdk:"config_type"`
+	NetworkingType types.String `tfsdk:"networking_type"`
+}
+
+func (d *EnvironmentsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environments"
+}
+
+func (d *EnvironmentsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "List all Managed Agent Environments.",
+
+		Attributes: map[string]schema.Attribute{
+			"environments": schema.ListNestedAttribute{
+				MarkdownDescription: "List of environments.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							MarkdownDescription: "ID of the Environment.",
+							Computed:            true,
+						},
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Name of the Environment.",
+							Computed:            true,
+						},
+						"config_type": schema.StringAttribute{
+							MarkdownDescription: "Configuration type.",
+							Computed:            true,
+						},
+						"networking_type": schema.StringAttribute{
+							MarkdownDescription: "Networking type.",
+							Computed:            true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *EnvironmentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data EnvironmentsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var allEnvs []EnvironmentDataSourceModel
+
+	var page *string
+	for {
+		params := &apiclient.ListEnvironmentsParams{}
+		if page != nil {
+			params.Page = page
+		}
+
+		httpResp, err := d.client.ListEnvironmentsWithResponse(ctx, params)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list environments, got error: %s", err))
+			return
+		}
+
+		if httpResp.StatusCode() != http.StatusOK {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list environments, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+			return
+		}
+
+		if httpResp.JSON200 == nil {
+			break
+		}
+
+		for _, e := range httpResp.JSON200.Data {
+			allEnvs = append(allEnvs, EnvironmentDataSourceModel{
+				Id:             types.StringValue(e.Id),
+				Name:           types.StringValue(e.Name),
+				ConfigType:     types.StringValue(e.Config.Type),
+				NetworkingType: types.StringValue(e.Config.Networking.Type),
+			})
+		}
+
+		if httpResp.JSON200.NextPage == nil || *httpResp.JSON200.NextPage == "" {
+			break
+		}
+		page = httpResp.JSON200.NextPage
+	}
+
+	data.Environments = allEnvs
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_organization_invites.go
+++ b/internal/provider/data_source_organization_invites.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type OrganizationInvitesDataSourceModel struct {

--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type UserDataSourceModel struct {

--- a/internal/provider/data_source_user_test.go
+++ b/internal/provider/data_source_user_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccUserDataSource(t *testing.T) {

--- a/internal/provider/data_source_users.go
+++ b/internal/provider/data_source_users.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type UsersDataSourceModel struct {

--- a/internal/provider/data_source_users_test.go
+++ b/internal/provider/data_source_users_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccUsersDataSource(t *testing.T) {

--- a/internal/provider/data_source_workspace_member_test.go
+++ b/internal/provider/data_source_workspace_member_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccWorkspaceMemberDataSource(t *testing.T) {

--- a/internal/provider/data_source_workspace_members.go
+++ b/internal/provider/data_source_workspace_members.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type WorkspaceMembersDataSourceModel struct {

--- a/internal/provider/data_source_workspace_members_test.go
+++ b/internal/provider/data_source_workspace_members_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccWorkspaceMembersDataSource(t *testing.T) {

--- a/internal/provider/data_source_workspace_test.go
+++ b/internal/provider/data_source_workspace_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccWorkspaceDataSource(t *testing.T) {

--- a/internal/provider/data_source_workspaces.go
+++ b/internal/provider/data_source_workspaces.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type WorkspacesDataSourceModel struct {

--- a/internal/provider/data_source_workspaces_test.go
+++ b/internal/provider/data_source_workspaces_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccWorkspacesDataSource(t *testing.T) {

--- a/internal/provider/model_agent.go
+++ b/internal/provider/model_agent.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AgentModel struct {
+	Id         types.String     `tfsdk:"id"`
+	Version    types.String     `tfsdk:"version"`
+	Name       types.String     `tfsdk:"name"`
+	System     types.String     `tfsdk:"system"`
+	Model      types.String     `tfsdk:"model"`
+	Tools      []AgentToolModel `tfsdk:"tools"`
+	McpServers []McpServerModel `tfsdk:"mcp_servers"`
+	Skills     []SkillModel     `tfsdk:"skills"`
+}
+
+type AgentToolModel struct {
+	Type types.String `tfsdk:"type"`
+}
+
+type McpServerModel struct {
+	Name types.String `tfsdk:"name"`
+	Type types.String `tfsdk:"type"`
+	Url  types.String `tfsdk:"url"`
+}
+
+type SkillModel struct {
+	SkillId types.String `tfsdk:"skill_id"`
+	Type    types.String `tfsdk:"type"`
+	Version types.String `tfsdk:"version"`
+}
+
+func (m *AgentModel) Fill(a apiclient.Agent) error {
+	m.Id = types.StringValue(a.Id)
+	m.Version = types.StringValue(a.Version)
+	m.Name = types.StringValue(a.Name)
+	m.System = types.StringPointerValue(a.System)
+	m.Model = types.StringPointerValue(a.Model)
+
+	if a.Tools != nil {
+		tools := make([]AgentToolModel, len(*a.Tools))
+		for i, t := range *a.Tools {
+			tools[i] = AgentToolModel{
+				Type: types.StringValue(t.Type),
+			}
+		}
+		m.Tools = tools
+	} else {
+		m.Tools = []AgentToolModel{}
+	}
+
+	if a.McpServers != nil {
+		servers := make([]McpServerModel, len(*a.McpServers))
+		for i, s := range *a.McpServers {
+			servers[i] = McpServerModel{
+				Name: types.StringValue(s.Name),
+				Type: types.StringValue(s.Type),
+				Url:  types.StringValue(s.Url),
+			}
+		}
+		m.McpServers = servers
+	} else {
+		m.McpServers = []McpServerModel{}
+	}
+
+	if a.Skills != nil {
+		skills := make([]SkillModel, len(*a.Skills))
+		for i, s := range *a.Skills {
+			skills[i] = SkillModel{
+				SkillId: types.StringValue(s.SkillId),
+				Type:    types.StringValue(s.Type),
+				Version: types.StringValue(s.Version),
+			}
+		}
+		m.Skills = skills
+	} else {
+		m.Skills = []SkillModel{}
+	}
+
+	return nil
+}

--- a/internal/provider/model_environment.go
+++ b/internal/provider/model_environment.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type EnvironmentModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	ConfigType     types.String `tfsdk:"config_type"`
+	NetworkingType types.String `tfsdk:"networking_type"`
+	Packages       types.Map    `tfsdk:"packages"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
+}
+
+func (m *EnvironmentModel) Fill(ctx context.Context, e apiclient.Environment) error {
+	m.Id = types.StringValue(e.Id)
+	m.Name = types.StringValue(e.Name)
+	m.ConfigType = types.StringValue(e.Config.Type)
+	m.NetworkingType = types.StringValue(e.Config.Networking.Type)
+	m.CreatedAt = types.StringPointerValue(e.CreatedAt)
+	m.UpdatedAt = types.StringPointerValue(e.UpdatedAt)
+
+	if e.Config.Packages != nil && len(*e.Config.Packages) > 0 {
+		elems := make(map[string]attr.Value, len(*e.Config.Packages))
+		for k, v := range *e.Config.Packages {
+			elems[k] = types.StringValue(v)
+		}
+		m.Packages = types.MapValueMust(types.StringType, elems)
+	} else {
+		m.Packages = types.MapNull(types.StringType)
+	}
+
+	return nil
+}

--- a/internal/provider/model_organization_invite.go
+++ b/internal/provider/model_organization_invite.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type OrganizationInviteModel struct {

--- a/internal/provider/model_workspace.go
+++ b/internal/provider/model_workspace.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type WorkspaceModel struct {

--- a/internal/provider/model_workspace_member.go
+++ b/internal/provider/model_workspace_member.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type WorkspaceMemberModel struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 // Ensure AnthropicProvider satisfies various provider interfaces.
@@ -40,7 +40,7 @@ func (p *AnthropicProvider) Metadata(ctx context.Context, req provider.MetadataR
 
 func (p *AnthropicProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "The Anthropic provider is used to interact with the Anthropic service.\n\nIf you find this provider useful, please consider supporting me through GitHub Sponsorship or Ko-Fi to help with its development.\n\n[![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA)](https://github.com/sponsors/jianyuan)\n[![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/L3L71DQEL)",
+		MarkdownDescription: "The Anthropic provider manages Anthropic resources including workspaces, organization members, and Managed Agents (agents, environments).",
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				MarkdownDescription: "API endpoint for the Anthropic service. Defaults to `https://api.anthropic.com`. It can be sourced from the `ANTHROPIC_BASE_URL` environment variable.",
@@ -99,6 +99,7 @@ func (p *AnthropicProvider) Configure(ctx context.Context, req provider.Configur
 		apiclient.WithHTTPClient(retryClient.StandardClient()),
 		apiclient.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("anthropic-version", "2023-06-01")
+			req.Header.Set("anthropic-beta", "agent-api-2026-03-01")
 			req.Header.Set("x-api-key", apiKey)
 			return nil
 		}),
@@ -114,6 +115,8 @@ func (p *AnthropicProvider) Configure(ctx context.Context, req provider.Configur
 
 func (p *AnthropicProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewAgentResource,
+		NewEnvironmentResource,
 		NewOrganizationInviteResource,
 		NewWorkspaceMemberResource,
 		NewWorkspaceResource,
@@ -122,6 +125,8 @@ func (p *AnthropicProvider) Resources(ctx context.Context) []func() resource.Res
 
 func (p *AnthropicProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewAgentsDataSource,
+		NewEnvironmentsDataSource,
 		NewOrganizationInvitesDataSource,
 		NewUserDataSource,
 		NewUsersDataSource,

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 type baseResource struct {

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -1,0 +1,325 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func NewAgentResource() resource.Resource {
+	return &AgentResource{}
+}
+
+var _ resource.Resource = &AgentResource{}
+var _ resource.ResourceWithImportState = &AgentResource{}
+
+type AgentResource struct {
+	baseResource
+}
+
+func (r *AgentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_agent"
+}
+
+func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages an Anthropic Managed Agent.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "ID of the Agent.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"version": schema.StringAttribute{
+				MarkdownDescription: "Version of the Agent. Increments on each update.",
+				Computed:            true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the Agent.",
+				Required:            true,
+			},
+			"model": schema.StringAttribute{
+				MarkdownDescription: "Model ID for the Agent (e.g. `claude-sonnet-4-5`, `claude-opus-4-5`).",
+				Required:            true,
+			},
+			"system": schema.StringAttribute{
+				MarkdownDescription: "System prompt for the Agent.",
+				Optional:            true,
+			},
+		},
+
+		Blocks: map[string]schema.Block{
+			"tools": schema.ListNestedBlock{
+				MarkdownDescription: "Tools available to the Agent.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							MarkdownDescription: "Tool type (e.g. `agent_toolset_20260401`).",
+							Required:            true,
+						},
+					},
+				},
+			},
+			"mcp_servers": schema.ListNestedBlock{
+				MarkdownDescription: "MCP servers available to the Agent.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Name of the MCP server.",
+							Required:            true,
+						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: "Type of the MCP server (e.g. `url`).",
+							Required:            true,
+						},
+						"url": schema.StringAttribute{
+							MarkdownDescription: "URL of the MCP server.",
+							Required:            true,
+						},
+					},
+				},
+			},
+			"skills": schema.ListNestedBlock{
+				MarkdownDescription: "Skills assigned to the Agent.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"skill_id": schema.StringAttribute{
+							MarkdownDescription: "ID of the skill.",
+							Required:            true,
+						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: "Skill type (`anthropic` or `custom`).",
+							Required:            true,
+						},
+						"version": schema.StringAttribute{
+							MarkdownDescription: "Version of the skill.",
+							Required:            true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *AgentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data AgentModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	body := apiclient.CreateAgentJSONRequestBody{
+		Name:  data.Name.ValueString(),
+		Model: data.Model.ValueString(),
+	}
+
+	if !data.System.IsNull() {
+		system := data.System.ValueString()
+		body.System = &system
+	}
+
+	if len(data.Tools) > 0 {
+		tools := make([]apiclient.AgentTool, len(data.Tools))
+		for i, t := range data.Tools {
+			tools[i] = apiclient.AgentTool{Type: t.Type.ValueString()}
+		}
+		body.Tools = &tools
+	}
+
+	if len(data.McpServers) > 0 {
+		servers := make([]apiclient.AgentMcpServer, len(data.McpServers))
+		for i, s := range data.McpServers {
+			servers[i] = apiclient.AgentMcpServer{
+				Name: s.Name.ValueString(),
+				Type: s.Type.ValueString(),
+				Url:  s.Url.ValueString(),
+			}
+		}
+		body.McpServers = &servers
+	}
+
+	if len(data.Skills) > 0 {
+		skills := make([]apiclient.AgentSkillRequest, len(data.Skills))
+		for i, s := range data.Skills {
+			skills[i] = apiclient.AgentSkillRequest{
+				Id:      s.SkillId.ValueString(),
+				Type:    s.Type.ValueString(),
+				Version: s.Version.ValueString(),
+			}
+		}
+		body.Skills = &skills
+	}
+
+	httpResp, err := r.client.CreateAgentWithResponse(ctx, body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create agent, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create agent, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to create agent, got empty response body")
+		return
+	}
+
+	if err := data.Fill(*httpResp.JSON200); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to fill data: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data AgentModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	httpResp, err := r.client.GetAgentWithResponse(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read agent, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read agent, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to read agent, got empty response body")
+		return
+	}
+
+	if err := data.Fill(*httpResp.JSON200); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to fill data: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data AgentModel
+	var state AgentModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+	model := data.Model.ValueString()
+	body := apiclient.UpdateAgentJSONRequestBody{
+		Version: state.Version.ValueString(),
+		Name:    &name,
+		Model:   &model,
+	}
+
+	if !data.System.IsNull() {
+		system := data.System.ValueString()
+		body.System = &system
+	}
+
+	tools := make([]apiclient.AgentTool, len(data.Tools))
+	for i, t := range data.Tools {
+		tools[i] = apiclient.AgentTool{Type: t.Type.ValueString()}
+	}
+	body.Tools = &tools
+
+	servers := make([]apiclient.AgentMcpServer, len(data.McpServers))
+	for i, s := range data.McpServers {
+		servers[i] = apiclient.AgentMcpServer{
+			Name: s.Name.ValueString(),
+			Type: s.Type.ValueString(),
+			Url:  s.Url.ValueString(),
+		}
+	}
+	body.McpServers = &servers
+
+	skills := make([]apiclient.AgentSkillRequest, len(data.Skills))
+	for i, s := range data.Skills {
+		skills[i] = apiclient.AgentSkillRequest{
+			Id:      s.SkillId.ValueString(),
+			Type:    s.Type.ValueString(),
+			Version: s.Version.ValueString(),
+		}
+	}
+	body.Skills = &skills
+
+	httpResp, err := r.client.UpdateAgentWithResponse(ctx, state.Id.ValueString(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update agent, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update agent, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to update agent, got empty response body")
+		return
+	}
+
+	if err := data.Fill(*httpResp.JSON200); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to fill data: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AgentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data AgentModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	httpResp, err := r.client.DeleteAgentWithResponse(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete agent, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete agent, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+}
+
+func (r *AgentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -1,0 +1,171 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func init() {
+	resource.AddTestSweepers("anthropic_agent", &resource.Sweeper{
+		Name: "anthropic_agent",
+		F: func(r string) error {
+			ctx := context.Background()
+
+			params := &apiclient.ListAgentsParams{}
+
+			for {
+				httpResp, err := acctest.SharedClient.ListAgentsWithResponse(ctx, params)
+				if err != nil {
+					return fmt.Errorf("unable to list agents: %s", err)
+				}
+
+				if httpResp.StatusCode() != http.StatusOK {
+					return fmt.Errorf("unable to list agents, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body))
+				}
+
+				if httpResp.JSON200 == nil {
+					break
+				}
+
+				for _, agent := range httpResp.JSON200.Data {
+					if !strings.HasPrefix(agent.Name, "tf-") {
+						continue
+					}
+
+					log.Printf("[INFO] Destroying agent %s", agent.Id)
+
+					_, err := acctest.SharedClient.DeleteAgentWithResponse(ctx, agent.Id)
+					if err != nil {
+						log.Printf("[ERROR] Unable to delete agent %s: %s", agent.Id, err)
+						continue
+					}
+
+					log.Printf("[INFO] Deleted agent %s", agent.Id)
+				}
+
+				if httpResp.JSON200.NextPage == nil || *httpResp.JSON200.NextPage == "" {
+					break
+				}
+				params.Page = httpResp.JSON200.NextPage
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccAgentResource_basic(t *testing.T) {
+	rn := "anthropic_agent.test"
+	agentName := acctest.RandomWithPrefix("tf-agent")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckManagedAgents(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentResourceConfig_basic(agentName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(agentName)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("model"), knownvalue.StringExact("claude-sonnet-4-5")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("version"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAgentResourceConfig_basic(agentName + "-updated"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(agentName+"-updated")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAgentResource_withTools(t *testing.T) {
+	rn := "anthropic_agent.test"
+	agentName := acctest.RandomWithPrefix("tf-agent")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckManagedAgents(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentResourceConfig_withTools(agentName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(agentName)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("system"), knownvalue.StringExact("You are a helpful assistant.")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAgentResource_withSystem(t *testing.T) {
+	rn := "anthropic_agent.test"
+	agentName := acctest.RandomWithPrefix("tf-agent")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckManagedAgents(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentResourceConfig_withSystem(agentName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("system"), knownvalue.StringExact("You are a DevOps assistant.")),
+				},
+			},
+		},
+	})
+}
+
+func testAccAgentResourceConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "anthropic_agent" "test" {
+	name  = %[1]q
+	model = "claude-sonnet-4-5"
+}
+`, name)
+}
+
+func testAccAgentResourceConfig_withTools(name string) string {
+	return fmt.Sprintf(`
+resource "anthropic_agent" "test" {
+	name   = %[1]q
+	model  = "claude-sonnet-4-5"
+	system = "You are a helpful assistant."
+
+	tools {
+		type = "agent_toolset_20251212"
+	}
+}
+`, name)
+}
+
+func testAccAgentResourceConfig_withSystem(name string) string {
+	return fmt.Sprintf(`
+resource "anthropic_agent" "test" {
+	name   = %[1]q
+	model  = "claude-sonnet-4-5"
+	system = "You are a DevOps assistant."
+}
+`, name)
+}

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -1,0 +1,240 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func NewEnvironmentResource() resource.Resource {
+	return &EnvironmentResource{}
+}
+
+var _ resource.Resource = &EnvironmentResource{}
+var _ resource.ResourceWithImportState = &EnvironmentResource{}
+
+type EnvironmentResource struct {
+	baseResource
+}
+
+func (r *EnvironmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment"
+}
+
+func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages an Anthropic Managed Agent Environment.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "ID of the Environment.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the Environment.",
+				Required:            true,
+			},
+			"config_type": schema.StringAttribute{
+				MarkdownDescription: "Configuration type. Currently only `cloud` is supported.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("cloud"),
+			},
+			"networking_type": schema.StringAttribute{
+				MarkdownDescription: "Networking type. One of `unrestricted` or `restricted`.",
+				Required:            true,
+			},
+			"packages": schema.MapAttribute{
+				MarkdownDescription: "Package versions to install (e.g. `{\"python\" = \"3.12\", \"node\" = \"20\"}`).",
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
+			"created_at": schema.StringAttribute{
+				MarkdownDescription: "RFC 3339 datetime string indicating when the Environment was created.",
+				Computed:            true,
+			},
+			"updated_at": schema.StringAttribute{
+				MarkdownDescription: "RFC 3339 datetime string indicating when the Environment was last updated.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (r *EnvironmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	body := apiclient.CreateEnvironmentJSONRequestBody{
+		Name: data.Name.ValueString(),
+		Config: apiclient.EnvironmentConfig{
+			Type: data.ConfigType.ValueString(),
+			Networking: apiclient.EnvironmentNetworking{
+				Type: data.NetworkingType.ValueString(),
+			},
+		},
+	}
+
+	if !data.Packages.IsNull() && !data.Packages.IsUnknown() {
+		packages := make(map[string]string)
+		resp.Diagnostics.Append(data.Packages.ElementsAs(ctx, &packages, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		body.Config.Packages = &packages
+	}
+
+	httpResp, err := r.client.CreateEnvironmentWithResponse(ctx, body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create environment, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create environment, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to create environment, got empty response body")
+		return
+	}
+
+	if err := data.Fill(ctx, *httpResp.JSON200); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to fill data: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *EnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	httpResp, err := r.client.GetEnvironmentWithResponse(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read environment, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read environment, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to read environment, got empty response body")
+		return
+	}
+
+	if err := data.Fill(ctx, *httpResp.JSON200); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to fill data: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *EnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+	config := apiclient.EnvironmentConfig{
+		Type: data.ConfigType.ValueString(),
+		Networking: apiclient.EnvironmentNetworking{
+			Type: data.NetworkingType.ValueString(),
+		},
+	}
+
+	if !data.Packages.IsNull() && !data.Packages.IsUnknown() {
+		packages := make(map[string]string)
+		resp.Diagnostics.Append(data.Packages.ElementsAs(ctx, &packages, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		config.Packages = &packages
+	}
+
+	body := apiclient.UpdateEnvironmentJSONRequestBody{
+		Name:   &name,
+		Config: &config,
+	}
+
+	httpResp, err := r.client.UpdateEnvironmentWithResponse(ctx, data.Id.ValueString(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update environment, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update environment, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to update environment, got empty response body")
+		return
+	}
+
+	if err := data.Fill(ctx, *httpResp.JSON200); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to fill data: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *EnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data EnvironmentModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	httpResp, err := r.client.DeleteEnvironmentWithResponse(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete environment, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete environment, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
+		return
+	}
+}
+
+func (r *EnvironmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/provider/resource_environment_test.go
+++ b/internal/provider/resource_environment_test.go
@@ -1,0 +1,167 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func init() {
+	resource.AddTestSweepers("anthropic_environment", &resource.Sweeper{
+		Name: "anthropic_environment",
+		F: func(r string) error {
+			ctx := context.Background()
+
+			params := &apiclient.ListEnvironmentsParams{}
+
+			for {
+				httpResp, err := acctest.SharedClient.ListEnvironmentsWithResponse(ctx, params)
+				if err != nil {
+					return fmt.Errorf("unable to list environments: %s", err)
+				}
+
+				if httpResp.StatusCode() != http.StatusOK {
+					return fmt.Errorf("unable to list environments, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body))
+				}
+
+				if httpResp.JSON200 == nil {
+					break
+				}
+
+				for _, env := range httpResp.JSON200.Data {
+					if !strings.HasPrefix(env.Name, "tf-") {
+						continue
+					}
+
+					log.Printf("[INFO] Destroying environment %s", env.Id)
+
+					_, err := acctest.SharedClient.DeleteEnvironmentWithResponse(ctx, env.Id)
+					if err != nil {
+						log.Printf("[ERROR] Unable to delete environment %s: %s", env.Id, err)
+						continue
+					}
+
+					log.Printf("[INFO] Deleted environment %s", env.Id)
+				}
+
+				if httpResp.JSON200.NextPage == nil || *httpResp.JSON200.NextPage == "" {
+					break
+				}
+				params.Page = httpResp.JSON200.NextPage
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccEnvironmentResource_basic(t *testing.T) {
+	rn := "anthropic_environment.test"
+	envName := acctest.RandomWithPrefix("tf-env")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckManagedAgents(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_basic(envName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(envName)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("config_type"), knownvalue.StringExact("cloud")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("networking_type"), knownvalue.StringExact("unrestricted")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("created_at"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEnvironmentResourceConfig_basic(envName + "-updated"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(envName+"-updated")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentResource_restricted(t *testing.T) {
+	rn := "anthropic_environment.test"
+	envName := acctest.RandomWithPrefix("tf-env")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckManagedAgents(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_restricted(envName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("networking_type"), knownvalue.StringExact("restricted")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentResource_withPackages(t *testing.T) {
+	rn := "anthropic_environment.test"
+	envName := acctest.RandomWithPrefix("tf-env")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckManagedAgents(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfig_withPackages(envName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(envName)),
+				},
+			},
+		},
+	})
+}
+
+func testAccEnvironmentResourceConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "anthropic_environment" "test" {
+	name            = %[1]q
+	networking_type = "unrestricted"
+}
+`, name)
+}
+
+func testAccEnvironmentResourceConfig_restricted(name string) string {
+	return fmt.Sprintf(`
+resource "anthropic_environment" "test" {
+	name            = %[1]q
+	networking_type = "restricted"
+}
+`, name)
+}
+
+func testAccEnvironmentResourceConfig_withPackages(name string) string {
+	return fmt.Sprintf(`
+resource "anthropic_environment" "test" {
+	name            = %[1]q
+	networking_type = "unrestricted"
+	packages = {
+		"python" = "3.12"
+	}
+}
+`, name)
+}

--- a/internal/provider/resource_organization_invite.go
+++ b/internal/provider/resource_organization_invite.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 func NewOrganizationInviteResource() resource.Resource {

--- a/internal/provider/resource_workspace.go
+++ b/internal/provider/resource_workspace.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 func NewWorkspaceResource() resource.Resource {

--- a/internal/provider/resource_workspace_member.go
+++ b/internal/provider/resource_workspace_member.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 func NewWorkspaceMemberResource() resource.Resource {

--- a/internal/provider/resource_workspace_member_test.go
+++ b/internal/provider/resource_workspace_member_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
 )
 
 func TestAccWorkspaceMemberResource(t *testing.T) {

--- a/internal/provider/resource_workspace_test.go
+++ b/internal/provider/resource_workspace_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/acctest"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/apiclient"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/acctest"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/apiclient"
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/jianyuan/terraform-provider-anthropic/internal/provider"
+	"github.com/frank-bee/terraform-provider-anthropic/internal/provider"
 )
 
 // Format Terraform code for use in documentation.
@@ -36,7 +36,7 @@ func main() {
 		// TODO: Update this string with the published name of your provider.
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "registry.terraform.io/jianyuan/anthropic",
+		Address: "registry.terraform.io/frank-bee/anthropic",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
## Summary

- Add `anthropic_agent` resource with full CRUD lifecycle, import support, tools, MCP servers, and skills configuration
- Add `anthropic_environment` resource with CRUD, import, packages, and networking config
- Add `anthropic_agents` and `anthropic_environments` data sources for listing
- OpenAPI spec extended with all Managed Agents API endpoints
- Acceptance tests passing against real Anthropic API (agents)
- Examples for all new resources and data sources
- Fork module path updated from jianyuan to frank-bee

## Beta Headers

- Agents API requires `agent-api-2026-03-01` beta header
- Environments API requires separate access (not yet available on test key)

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` unit tests pass
- [x] `TF_ACC=1` acceptance tests pass for agent resources (basic, tools, system prompt)
- [ ] Environment acceptance tests pending API access